### PR TITLE
Fix MediaRemoteBridge callback signature and enum reference

### DIFF
--- a/Sources/MediaRemoteBridge.h
+++ b/Sources/MediaRemoteBridge.h
@@ -41,5 +41,5 @@ FOUNDATION_EXPORT void MRRegisterForNowPlayingNotifications(void);
 FOUNDATION_EXPORT void MRUnregisterForNowPlayingNotifications(void);
 FOUNDATION_EXPORT void MRGetNowPlayingInfo(void (^block)(NSDictionary *info));
 FOUNDATION_EXPORT void MRGetIsPlaying(void (^block)(BOOL playing));
-FOUNDATION_EXPORT void MRSentCommand(enum MRCommand command);
+FOUNDATION_EXPORT void MRSentCommand(MRCommand command);
 FOUNDATION_EXPORT void MRSeekToTime(NSTimeInterval seconds);


### PR DESCRIPTION
## Summary
- Replace block-based CFNotification callbacks with static function callbacks
- Use MRCommand typedef directly in `MRSentCommand` to avoid enum specifier error

## Testing
- `clang -fobjc-arc -fmodules -c Sources/MediaRemoteBridge.m -o /tmp/MediaRemoteBridge.o` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_689a1c7e1408832b935d981a34bd1efa