### PR TITLE
Fix MediaRemote wrapper recursion and enum ambiguity

### DIFF
--- a/Sources/MRShims.swift
+++ b/Sources/MRShims.swift
@@ -1,6 +1,6 @@
 import Foundation
 
-func MRGetNowPlayingInfo(_ block: @escaping ([String: Any]) -> Void) {
+func MRBridgeGetNowPlayingInfo(_ block: @escaping ([String: Any]) -> Void) {
     MRGetNowPlayingInfo { info in
         var dict: [String: Any] = [:]
         info.forEach { key, value in if let k = key as? String { dict[k] = value } }
@@ -8,10 +8,10 @@ func MRGetNowPlayingInfo(_ block: @escaping ([String: Any]) -> Void) {
     }
 }
 
-func MRGetIsPlaying(_ block: @escaping (Bool) -> Void) { MRGetIsPlaying { playing in block(playing) } }
+func MRBridgeGetIsPlaying(_ block: @escaping (Bool) -> Void) {
+    MRGetIsPlaying { playing in block(playing) }
+}
 
-enum MRCommandSwift: Int { case togglePlayPause = 0, play = 1, pause = 2, stop = 3, nextTrack = 4, previousTrack = 5, changePlaybackPosition = 13 }
-
-func MRSentCommand(_ cmd: MRCommandSwift) { MRSentCommand(MRCommand(rawValue: cmd.rawValue)!) }
-
-func MRSeek(to seconds: Double) { MRSeekToTime(seconds) }
+func MRSeek(to seconds: Double) {
+    MRSeekToTime(seconds)
+}

--- a/Sources/NowPlayingService.swift
+++ b/Sources/NowPlayingService.swift
@@ -38,12 +38,12 @@ final class NowPlayingService: ObservableObject {
     }
 
     func refreshNowPlaying() {
-        MRGetNowPlayingInfo { info in
+        MRBridgeGetNowPlayingInfo { info in
             DispatchQueue.main.async {
                 self.apply(info: info)
             }
         }
-        MRGetIsPlaying { playing in
+        MRBridgeGetIsPlaying { playing in
             DispatchQueue.main.async { self.isPlaying = playing }
         }
     }


### PR DESCRIPTION
## Summary
- Rename Swift helper functions to `MRBridgeGetNowPlayingInfo`/`MRBridgeGetIsPlaying` to avoid name collisions with C functions
- Remove duplicate MRCommand enum and wrapper so calls directly use the bridged `MRCommand`
- Update `NowPlayingService` to use the new helper names

## Testing
- `make run` *(fails: clang: No such file or directory)*
- `apt-get update` *(fails: repository ... is not signed / 403 Forbidden)*

------
https://chatgpt.com/codex/tasks/task_e_689a20ff6878832b97ec4755b5144c4e